### PR TITLE
Fix two issues with the gdb wrapper.

### DIFF
--- a/exploitable/lib/analyzers.py
+++ b/exploitable/lib/analyzers.py
@@ -222,11 +222,11 @@ def isSignalInList(target, siglist):
     '''
     if not isOnSignal(target):
         return False
+    tsigno = target.si_signo() # only get this ONCE per function call
     for s in siglist:
         signo = getattr(signal, s, None) # not all sigs may be defined
-        if signo:
-            if signo == target.si_signo():
-                return True
+        if signo and signo == tsigno:
+            return True
     return False
 
 def isNearNull(addr):

--- a/exploitable/lib/gdb_wrapper.py
+++ b/exploitable/lib/gdb_wrapper.py
@@ -400,6 +400,8 @@ class Target():
     def __init__(self):
         self.check_inferior_state()
         gdb.execute("set disassembly-flavor intel", False, True)
+        self.signo = None
+        self._si_addr = None
 
     def check_inferior_state(self):
         if len(gdb.inferiors()) != 1:
@@ -455,12 +457,21 @@ class Target():
         # $_siginfo is not available it to call __str__() -- otherwise
         # (such as when casting the Gdb.Value to another type), GDB may
         # force Python to abruptly exit rather than raising an exception
-        str(gdb.parse_and_eval("$_siginfo.si_signo"))
-        return gdb.parse_and_eval("$_siginfo.si_signo")
+        if self.signo is None:
+            x = gdb.parse_and_eval("$_siginfo.si_signo")
+            str(x)
+            self.signo = x
+        # this call can be _really_ slow if done multiple times
+        # just cache the result and only ever check it once
+        return self.signo
 
     def si_addr(self):
-        str(gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr"))
-        return gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr")
+        if self._si_addr is None:
+            x = gdb.parse_and_eval("$_siginfo._sifields._sigfault.si_addr")
+            str(x)
+            self._si_addr = x
+        # see comment for si_signo
+        return self._si_addr
 
 def getTarget():
     '''


### PR DESCRIPTION
- Add support for C++ functions that contain colons in their name (namespaces/classes, etc)
- Cache some gdb lookups that were very slow for large programs.
