### PR TITLE
NoThreadRunning exception handling added

### DIFF
--- a/exploitable/exploitable.py
+++ b/exploitable/exploitable.py
@@ -203,9 +203,18 @@ class ExploitableCommand(gdb.Command):
             return
 
         import logging
+        import lib.gdb_wrapper.x86 as gdb_wrapper
         try:
             target = arch.getTarget(args.asan_log, args.backtrace_limit)
             c = classifier.Classifier().getClassification(target)
+        except gdb_wrapper.NoThreadRunningError as e:
+            # Prevent exploitable.py from raising an exception if no threads
+            # are running (our target exited gracefully). These exceptions
+            # would interrupt the automatic crash classification process in gdb
+            # scripts that analyze many crash samples.
+            gdb.write("\nShort description: GracefulExit\n")
+            gdb.write("Exploitability Classification: NOT_EXPLOITABLE\n")
+            return
         except Exception as e:
             logging.exception(e)
             raise e

--- a/exploitable/exploitable.py
+++ b/exploitable/exploitable.py
@@ -207,14 +207,19 @@ class ExploitableCommand(gdb.Command):
         try:
             target = arch.getTarget(args.asan_log, args.backtrace_limit)
             c = classifier.Classifier().getClassification(target)
-        except gdb_wrapper.NoThreadRunningError as e:
+        except gdb_wrapper.NoThreadRunningError:
             # Prevent exploitable.py from raising an exception if no threads
             # are running (our target exited gracefully). These exceptions
             # would interrupt the automatic crash classification process in gdb
             # scripts that analyze many crash samples.
-            gdb.write("\nShort description: GracefulExit\n")
-            gdb.write("Exploitability Classification: NOT_EXPLOITABLE\n")
-            return
+            c = classifier.Classification(arch.x86Target)
+            dummy_tag = dict(ranking=(0, 0),
+                    category="NOT_EXPLOITABLE",
+                    desc="The target process exited normally.",
+                    short_desc="GracefulExit",
+                    explanation="The target process exited normally.",
+                    hash=classifier.AttrDict(major=0, minor=0))
+            c.__add__(classifier.Tag(dummy_tag))
         except Exception as e:
             logging.exception(e)
             raise e

--- a/exploitable/lib/gdb_wrapper/x86.py
+++ b/exploitable/lib/gdb_wrapper/x86.py
@@ -90,6 +90,12 @@ class GdbWrapperError(RuntimeError):
     '''
     pass
 
+class NoThreadRunningError(GdbWrapperError):
+    '''
+    Base class for NoThreadRunning errors
+    '''
+    pass
+
 class ProcMaps(list):
     '''
     A list of process address mappings. This object should only be instantiated
@@ -492,7 +498,7 @@ class Target(object):
         if len(gdb.inferiors()) != 1:
             raise GdbWrapperError("Unsupported number of inferiors ({})".format(len(gdb.inferiors())))
         if len(gdb.inferiors()[0].threads()) == 0:
-            raise GdbWrapperError("No threads running")
+            raise NoThreadRunningError("No threads running")
         if not gdb.inferiors()[0].threads()[0].is_stopped:
             raise GdbWrapperError("Inferior's primary thread is not stopped")
 


### PR DESCRIPTION
I'm using exploitable in gdb scripts for crash classification of thousands of crashes. If a crash sample does not lead to an actual crash in the target, exploitable complains that no threads are running at all (which is fine). The problem here is that exploitable raises an exception (`GdbWrapperError`) which completely aborts the execution of the gdb script.

So I'd like to propose a quick workaround that handles this type of "error" condition and prints a short description indicating that the target binary exited gracefully and is not exploitable (~~ok, this might be done in a more elegant way like creating a `Classification` object and manually setting its attributes accordingly instead of just printing and returning?!~~ Done.).

If you think this fix is of no general use and I'm better off redesigning my gdb scripts, please let me know. ;)