### PR TITLE
Fixes requirement of running from exe directory

### DIFF
--- a/triage.py
+++ b/triage.py
@@ -64,7 +64,8 @@ import warnings
 import sys
 
 # allows for un-pickling of exploitable's Classification objects
-sys.path.append("./exploitable")
+file_path = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(file_path, "exploitable"))
 
 class TriagedStates(list):
     '''
@@ -110,7 +111,8 @@ class Triager(object):
     An object that can triage a set of inferior invocations via calls to
     GDB.
     '''
-    gdb_cmd = "gdb --batch -ex \"source exploitable/exploitable.py\" " +\
+    exploitable_py = os.path.normpath(os.path.join(file_path, 'exploitable/exploitable.py'))
+    gdb_cmd = "gdb --batch -ex \"source " + exploitable_py + "\" " +\
                 "-ex run -ex \"exploitable -p %s\" --args"
     tmp_file = "/tmp/triage.pkl"
     verbose = False


### PR DESCRIPTION
Exploitable requires running the script from the directory that the
script resides in. This fixes that by determining the path to the python
script and using it in two places: 1) adding to the python path for
pickle purposes, and 2) for the commandline to gdb

After this change, you should be able to run exploitable from any
directory