### PR TITLE
fix exception in json if test cases don't crash

### DIFF
--- a/exploitable/lib/classifier.py
+++ b/exploitable/lib/classifier.py
@@ -102,6 +102,9 @@ class Classification(AttrDict):
 
     # for python3
     def __lt__(self, other):
+        if other is None:
+            return False
+
         if not issubclass(type(other), type(self)):
             raise TypeError("cannot compare type {} to type {}".format(type(other), type(self)))
 
@@ -116,6 +119,9 @@ class Classification(AttrDict):
         return False
 
     def __cmp__(self, other):
+        if other is None:
+            return 1
+
         if not issubclass(type(other), type(self)):
             raise TypeError("cannot compare type {} to type {}".format(type(other), type(self)))
 


### PR DESCRIPTION
Currently if a test case doesn't crash (e.g. it crashes in a fuzzing
environment but not in a naive triage environment), JSON output crashes
with an exception when sorting the results. This fixes the issue by
allowing a Classification to compare itself to None without throwing an
exception