### PR TITLE
Fall back to true faulting frame

### DIFF
--- a/exploitable/lib/gdb_wrapper/x86.py
+++ b/exploitable/lib/gdb_wrapper/x86.py
@@ -513,7 +513,7 @@ class Target(object):
             if not frame.blacklisted:
                 return frame
         warnings.warn("All frames blacklisted")
-        return None
+        return self.backtrace()[0]
 
     @staticmethod
     def sym_addr(sym):


### PR DESCRIPTION
If all frames are blacklisted we should still return something for the faulting frame. Not only is it generally sensible (eg if the stack is completely blown we still return `Faulting Frame: # 4 None at blah blah blah`) but it makes automatic parsing easier.