### PR TITLE
Improved stack hash when all frames blacklisted

### DIFF
--- a/exploitable/lib/gdb_wrapper/x86.py
+++ b/exploitable/lib/gdb_wrapper/x86.py
@@ -342,8 +342,8 @@ class Backtrace(list):
         frame = self._next_frame()
         hc = 0
         i = 0
-        major = "0"
-        minor = "0"
+        major = ""
+        minor = ""
         self.abnormal_termination = False
         while frame:
             frame = self._next_frame(target, frame, i)
@@ -359,10 +359,11 @@ class Backtrace(list):
             if not self._in_blacklist(frame):
                 if hc < major_depth:
                     major = hashlib.md5((major + str(frame)).encode()).hexdigest()
-                minor = hashlib.md5((minor + str(frame)).encode()).hexdigest()
                 hc += 1
             else:
                 frame.blacklisted = True
+            # logic change - use ALL frames for the minor hash
+            minor = hashlib.md5((minor + str(frame)).encode()).hexdigest()
             self.append(frame)
 
             # some versions of the GDB Python API do not expose a frame unwind
@@ -382,6 +383,11 @@ class Backtrace(list):
 
             if limit and i >= limit:
                 break
+
+        # if all major frames were blacklisted, call the major hash 0x0
+        # but make it 32 bytes long to make parsing easy.
+        if len(major) == 0:
+            major = '0' * 32
 
         self.hash = AttrDict(major=major, minor=minor)
 


### PR DESCRIPTION
Two changes:

1. All frames contribute to the minor hash. This is a good idea anyway, since we might be able to differentiate two crashes that have the same general fault logic but cause different paths through the libc error handling (or just crash in a libc frame, like __GI_libc_free), which is a thing we want.

2. Not entirely sure how to handle the major hash here. In the end I went with calling it 00000000000000000000000000000000 but it might be better to do something else. The two main options are

- hash the blacklisted frames instead
- use a canary value (badbadbadbad etc) although arguably the zero works for this

Some kind of change is probably a good plan, once again to make automatic parsing easier.