### PR TITLE
Quick-fix for crash in non-english gdb (#29)

### DIFF
--- a/exploitable/lib/gdb_wrapper/x86.py
+++ b/exploitable/lib/gdb_wrapper/x86.py
@@ -48,7 +48,7 @@
 '''
 A collection of Python objects that wrap and extend the GDB Python API.
 
-This file contains base class logic for GDB wrapper object as well as 
+This file contains base class logic for GDB wrapper object as well as
 x86-specific logic. Someday these should be separated.
 '''
 try:
@@ -128,11 +128,11 @@ class ProcMaps(list):
         self._files = set()
 
     def __str__(self):
-        result = ["{:10} {:10} {:10} {:10} {} {}".format("start", "end", 
+        result = ["{:10} {:10} {:10} {:10} {} {}".format("start", "end",
             "size", "offset", "name", "sect")]
         for m in self:
             result.append("{0.start:#08x} {0.end:#08x} {0.size:#08x} " +\
-                "{0.offset:#08x} {0.name} {1}".format(m, 
+                "{0.offset:#08x} {0.name} {1}".format(m,
                     getattr(m, "sect", "?")))
         result.append("")
         return "\n".join(result)
@@ -182,8 +182,8 @@ class Instruction(object):
 
     def __init__(self, gdbstr):
         '''
-        Parses gdbstr to populate self; this method only covers parsing that 
-        is common across processor architectures. The remainder of the parsing  
+        Parses gdbstr to populate self; this method only covers parsing that
+        is common across processor architectures. The remainder of the parsing
         is implemented in subclasses.
         '''
         self.gdbstr = gdbstr
@@ -197,12 +197,12 @@ class Instruction(object):
     def __str__(self):
         return self.gdbstr
 
-class x86Instruction(Instruction): 
+class x86Instruction(Instruction):
     '''
     A disassembled Intel instruction. See Instruction class comments for more
     details.
     '''
-    
+
     def __init__(self, gdbstr):
         '''
         Parses gdbstr to populate self.
@@ -230,7 +230,7 @@ class x86Instruction(Instruction):
 
         toks = []
         for t in self.gdbstr.split():
-            t = t.strip().strip(":") 
+            t = t.strip().strip(":")
             if t:
                 toks.append(t)
         self.addr = int(toks[0], 16)
@@ -242,7 +242,7 @@ class x86Instruction(Instruction):
         else:
             self.mnemonic = toks[1]
             self.inst = " ".join(toks[2:])
-             
+
         if self.inst == "": # handle "ret", "iret", et al.
             return
 
@@ -250,7 +250,7 @@ class x86Instruction(Instruction):
         self.operands = [Operand(o) for o in self.inst.split(",")]
         for a, o in zip(("dest", "source", "aux"), self.operands):
             setattr(self, a, o)
-       
+
 class Operand(object):
     '''
     A disassembled instruction operand that can be evaluated. Notable
@@ -394,7 +394,7 @@ class Backtrace(list):
     def _next_frame(self, target=None, frame=None, i=None):
         '''
         Gets the next frame (the frame after 'frame').
-        If called without params (or if target is None, at least) then the 
+        If called without params (or if target is None, at least) then the
         innermost frame is obtained from GDB.
         '''
         if not target:
@@ -479,8 +479,8 @@ class Target(object):
                                        in\s+section\s+\.text(\s+
                                        of\s+(?P<lib>.*?)\s*)?$""", re.VERBOSE)
     _re_gdb_addr_bit = re.compile(r"^gdbarch_dump: addr_bit = ([0-9]+)$", re.MULTILINE)
-    _re_gdb_osabi = re.compile(r"\(currently \"(.*)\"\)")
-    _re_gdb_arch = re.compile(r"\(currently\s+(.+)\)")
+    _re_gdb_osabi = re.compile(r"\(\w+ \"(.*)\"\)")
+    _re_gdb_arch = re.compile(r"\(\w+\s+(.+)\)")
 
     # these functions and libs are not considered to be at fault for a crash
     blacklist = AttrDict(functions=("__kernel_vsyscall", "abort", "raise",
@@ -575,7 +575,7 @@ class Target(object):
 
 class x86Target(Target):
     '''
-    A wrapper for an x86 Linux GDB Inferior. 
+    A wrapper for an x86 Linux GDB Inferior.
     '''
 
     def __init__(self, bt_limit=0):


### PR DESCRIPTION
This is just a quick-fix that prevents `exploitable` from crashing in non-english gdb environments when simply running `exploitable` from the `gdb` prompt (as reported in #29).
However this fix cures just one occurance of the problem. For other `exploitable` commands it may still crash!