### PR TITLE
setup.py modified to be setuptools compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ class CustomBdistEgg(bdist_egg):
         # run default setup procedure
         bdist_egg.run(self)
 
-        from distutils.sysconfig import get_python_lib
+        from sysconfig import get_path
 
-        path_to_exploitable = os.path.join(get_python_lib(),
+        path_to_exploitable = os.path.join(get_path('platlib'),
                                            os.path.basename(self.egg_output),
                                            'exploitable',
                                            'exploitable.py')

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 
 # The MIT License (MIT)
-# 
+#
 # Copyright (c) 2013 Jonathan Foote
-# 
+#           (c) 2015 rc0r
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
 # the Software without restriction, including without limitation the rights to
 # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 # the Software, and to permit persons to whom the Software is furnished to do so,
 # subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 # FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -21,51 +22,83 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from setuptools.command.bdist_egg import bdist_egg
+from setuptools import setup, Command, find_packages
+
 import os
-from optparse import OptionParser
+import subprocess
+import shlex
+
+
+class CustomBdistEgg(bdist_egg):
+    """
+    Our custom "install" class that overrides the default setuptools
+    bdist_egg procedure. We use bdist_egg here because in contrary
+    to a custom install it also gets called when setup is run from
+    easy_install.
+    """
+    def run(self):
+        # run default setup procedure
+        bdist_egg.run(self)
+
+        from distutils.sysconfig import get_python_lib
+
+        path_to_exploitable = os.path.join(get_python_lib(),
+                                           os.path.basename(self.egg_output),
+                                           'exploitable',
+                                           'exploitable.py')
+        print('\x1b[0;32m**********************************************')
+        print(' Install complete! Source exploitable.py from')
+        print(' your .gdbinit to make it available in GDB:')
+        print('')
+        print(' \x1b[1;37mecho \"source %s\" >> ~/.gdbinit\x1b[0;32m' % path_to_exploitable)
+        print('**********************************************\x1b[0m')
+
+
+class TestCommand(Command):
+    """
+    Custom test command.
+    """
+    description = 'Run exploitable tests.'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        print("testing for x86, for ARM and more args, see scripts in test/ dir")
+        run("test/x86.sh build run_test clean")
+        print("done")
+
 
 def run(cmd):
-    import subprocess, shlex
-    print cmd
-    subprocess.check_call(shlex.split(cmd))
+    try:
+        print(cmd)
+        subprocess.check_call(shlex.split(cmd))
+    except subprocess.CalledProcessError:
+        pass
 
-if __name__ == "__main__":
-    usage = "usage: %prog install|uninstall|test [path]"
-    desc = "[Un]installs exploitable gdb plugin to PATH, or GDB data dir if no "  +\
-           "path is specified."
-        
-    op = OptionParser(description=desc, usage=usage)
 
-    (opts, args) = op.parse_args()
-    if len(args) < 1:
-        op.error("wrong number of arguments")
-    if len(args) == 1:
-        import subprocess, shlex, re
-        path = subprocess.check_output(shlex.split(
-            "gdb --batch -ex 'show data-directory'")).strip()
-        match = re.match("^.*\"(.*)\".*$", path)
-        if not match:
-            raise Exception("GDB data directory parse command failed, "
-                    "make sure GDB is installed and try specifying a path "
-                    "manually")
-        path = match.groups()[0]
-    elif len(args) == 2:
-        path = args[1]
-    path = os.path.join(path, 'python', 'gdb', 'command')
-    print "Target path is %s" % path
-    if args[0] == "install":
-        from shutil import copy, move
-        run("cp -R exploitable/ %s/exploitable_lib" % path)
-        run("touch %s/exploitable_lib/__init__.py" % path)
-        run("cp gdb_install_stub.py %s/exploitable.py" % path)
-    elif args[0] == "uninstall":
-        run("rm %s/exploitable.py" % path)
-        run("rm -rf %s/exploitable_lib" % path)
-    elif args[0] == "test":
-        if len(args) == 2:
-            op.error("y u specify path with test?")
-        print "testing for x86, for ARM and more args, see scripts in test/ dir"
-        run("test/x86.sh build run_test clean")
-        print "done"
-    else:
-        op.error("first arg is incorrect")
+dependencies = []
+
+setup(
+    name='exploitable',
+    version='1.32',
+    url='https://github.com/jfoote/exploitable',
+    author='Jonathan Foote',
+    author_email='jmfoote@loyola.edu',
+    description='The \'exploitable\' GDB plugin.',
+    long_description=open('./README.md', 'r').read(),
+    requires=dependencies,
+    packages=find_packages(),
+    platforms=[
+        'Any'
+    ],
+    cmdclass={
+        'bdist_egg': CustomBdistEgg,
+        'test': TestCommand
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,22 @@ class CustomBdistEgg(bdist_egg):
         # run default setup procedure
         bdist_egg.run(self)
 
-        from sysconfig import get_path
+        import sys
 
-        path_to_exploitable = os.path.join(get_path('platlib'),
+        # Check whether setup.py is run from inside a virtualenv and get the
+        # appropriate install location for exploitable.py.
+        if hasattr(sys, 'real_prefix'):
+            # Inside virtualenv:
+            #   Use Python standard library location.
+            from distutils.sysconfig import get_python_lib
+            install_base_path = get_python_lib()
+        else:
+            # Not inside virtualenv, operating on a real Python environment:
+            #   Use location for Python site-specific, platform-specific files.
+            from sysconfig import get_path
+            install_base_path = get_path('platlib')
+
+        path_to_exploitable = os.path.join(install_base_path,
                                            os.path.basename(self.egg_output),
                                            'exploitable',
                                            'exploitable.py')


### PR DESCRIPTION
As discussed in #28 I modified the `setup.py` script to be `setuptools` compliant. This way `exploitable` can automatically be installed as a dependency by the setup scripts of other python packages (see `setup.py` of https://github.com/rc0r/afl-utils for an example).
Additionaly `exploitable` could be added to the Python package index.

Please make sure to check the package info and description as well as the contact info and modify as needed (lines 102-111)!

**Edit (2015-12-31):** Line numbers updated to reflect latest changes!