### PR TITLE
fix a function signature in a test

### DIFF
--- a/exploitable/tests/testPossibleStackCorruption.c
+++ b/exploitable/tests/testPossibleStackCorruption.c
@@ -3,7 +3,7 @@
 
 int i;
 
-int crash() {
+void crash() {
     char a[1];
     for (i = 0; i< 20480; i++) {
         a[i] = 'A';


### PR DESCRIPTION
remove warning testPossibleStackCorruption.c:12:1: warning: control reaches end of non-void function [-Wreturn-type]'