### PR TITLE
Make the last print in triage.py work with Python 2.7

### DIFF
--- a/triage.py
+++ b/triage.py
@@ -54,6 +54,7 @@
 A simple batch wrapper script for the CERT 'exploitable' GDB extension.
 '''
 
+from __future__ import print_function
 from optparse import OptionParser
 from string import Template
 import subprocess


### PR DESCRIPTION
With 'print' on Python 2.7,  ("\n\n\n\n", results) is interpteted as a tuple and can't be printed correctly