### PR TITLE
Added initial support for the MIPS CPU architecture.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -24,3 +24,7 @@ Will Dormann of CERT at Carnegie Mellon University
 Allen Householder of CERT at Carnegie Mellon University
   Contributed updated CMU license text
   https://github.com/ahouseholder
+
+Thomas Barabosch of Fraunhofer FKIE
+  Added support for MIPS.
+  https://github.com/tbarabosch

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ jmfoote@loyola.edu
 Requirements 
 ====
 
-- Compatible x86/x86_64/ARM Linux
+- Compatible x86/x86_64/ARM/MIPS Linux
 - Compatible GDB 7.2 or later
 - Python 2.7 or later (for triage.py)
 

--- a/exploitable/lib/analyzers/mips.py
+++ b/exploitable/lib/analyzers/mips.py
@@ -1,0 +1,73 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Thomas Barabosch of Fraunhofer FKIE
+# <thomas.barabosch (at) fkie.fraunhofer.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+import re
+import signal
+
+from lib.tools import memoized
+from lib.analyzers.x86 import Analyzer
+
+
+class MipsAnalyzer(Analyzer):
+    '''
+    An analyzer for an MIPS Linux GDB target. See x86.py for more info on 
+    Analyzers.
+    '''
+
+    def __init__(self, target):
+        Analyzer.__init__(self, target)
+
+    @memoized
+    def isReturnAv(self):
+        rets = ["jar", "jr"]
+        return self.isAccessViolationSignal() and \
+            (self.target.current_instruction() and
+             (self.target.current_instruction().mnemonic in rets))
+
+    @memoized
+    def isBlockMove(self):
+        return False
+
+    @memoized
+    def isJumpInstruction(self):
+        ins = self.target.current_instruction()
+        # https://www2.cs.duke.edu/courses/fall13/compsci250/MIPS32_QRC.pdf
+        jumps = ["b", "bal", "beq", "beqz", "bgez", "begezal", "bgtz",
+                 "belz", "bltz", "bltzal", "bne", "bnez", "j", "jal",
+                 "jalr", "jr"]
+        return ins and ins.mnemonic in jumps
+
+    @memoized
+    # TODO: think about MIPS delay slot!!!!
+    def isBranchAv(self):
+        if not self.isAccessViolationSignal():
+            return False
+        return self.isJumpInstruction()
+
+    @memoized
+    def faultingAddress(self):
+        if self.isJumpInstruction():
+            # si_addr does not always contain a valid faulting address, but
+            # jump instructions always access the dest op and GDB always displays
+            # the absolute addr, so we can use the dest op instead of si_addr here.
+            # FIXME: check type of instruction and use the corresponding operand, e.g. 1 instead of 0
+            return self.target.current_instruction().operands[0].eval()
+        return self.target.si_addr()

--- a/exploitable/lib/arch.py
+++ b/exploitable/lib/arch.py
@@ -1,17 +1,17 @@
 # The MIT License (MIT)
-# 
+#
 # Copyright (c) 2013 Jonathan Foote
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
 # the Software without restriction, including without limitation the rights to
 # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 # the Software, and to permit persons to whom the Software is furnished to do so,
 # subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 # FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -39,6 +39,7 @@ except ImportError as e:
     raise ImportError("This script must be run in GDB: ", str(e))
 
 from lib.gdb_wrapper.arm import ArmTarget
+from lib.gdb_wrapper.mips import MipsTarget
 from lib.gdb_wrapper.qnx import QnxTarget
 from lib.gdb_wrapper.asan import ASanTarget
 from lib.gdb_wrapper.x86 import Target, x86Target
@@ -46,12 +47,15 @@ from lib.gdb_wrapper.x86 import Target, x86Target
 from lib.analyzers.x86 import Analyzer
 from lib.analyzers.asan import ASanAnalyzer
 from lib.analyzers.arm import ArmAnalyzer
+from lib.analyzers.mips import MipsAnalyzer
+
 
 class ArmASanTarget(ASanTarget, ArmTarget):
     '''
     A wrapper for an ARM Linux GDB Inferior enhanced with ASAN log output.
     '''
     pass
+
 
 class QnxASanTarget(ASanTarget, QnxTarget):
     '''
@@ -60,24 +64,31 @@ class QnxASanTarget(ASanTarget, QnxTarget):
     '''
     pass
 
+
 class ArmASanAnalyzer(ArmAnalyzer, ASanAnalyzer):
     '''
     A rule analyzer for ASAN log output from executing on ARM Linux. 
-    ''' 
+    '''
     pass
 
-def getTarget(asan_log_file=None, bt_limit=0): 
+
+def getTarget(asan_log_file=None, bt_limit=0):
     ''' 
     Returns the current Target, which is a Python wrapper representing the 
     current state of the underlying Linux GDB Inferior object. This function
     selects a Target and Analyzer based on the architecture of the system at 
     runtime.
-    ''' 
+    '''
 
     # Get OS info.  TODO: verify this works on older versions of GDB (7.2)
-    osabi = Target._re_gdb_osabi.search(str(gdb.execute("show osabi", False, 
-        True))).group(1)
-    arch = Target._re_gdb_arch.search(str(gdb.execute("show architecture", False, True))).group(1)
+    osabi = Target._re_gdb_osabi.search(str(gdb.execute("show osabi", False,
+                                                        True))).group(1)
+    arch_str = str(gdb.execute("show architecture", False, True))
+    # if we set the arch in gdbmultiarch it is "assumed"
+    if "assumed" in arch_str:
+        arch = arch_str
+    else:
+        arch = Target._re_gdb_arch.search(arch_str).group(1)
 
     # Instantiate a target based on the params and OS info
     # ASAN + i386 + *
@@ -98,7 +109,7 @@ def getTarget(asan_log_file=None, bt_limit=0):
     # * + ARM + QNX
     elif arch.lower()[:3] == "arm" and osabi == "QNX Neutrino":
         target = QnxTarget(bt_limit)
-        target.analyzer = ArmAnalyzer(target) 
+        target.analyzer = ArmAnalyzer(target)
         return target
     # * + i386 + *
     elif arch.startswith("i386"):
@@ -110,7 +121,11 @@ def getTarget(asan_log_file=None, bt_limit=0):
         target = ArmTarget(bt_limit)
         target.analyzer = ArmAnalyzer(target)
         return target
+    elif "mips" in arch.lower():
+        target = MipsTarget(bt_limit)
+        target.analyzer = MipsAnalyzer(target)
+        return target
     else:
         raise NotImplementedError("no support for arch=%s and osabi=%s" % (arch, osabi))
-    
+
     return Target(bt_limit)

--- a/exploitable/lib/gdb_wrapper/mips.py
+++ b/exploitable/lib/gdb_wrapper/mips.py
@@ -1,0 +1,211 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Thomas Barabosch of Fraunhofer FKIE
+# <thomas.barabosch (at) fkie.fraunhofer.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+try:
+    import gdb
+except ImportError as e:
+    raise ImportError("This script must be run in GDB: ", str(e))
+
+import os
+import re
+import warnings
+
+from lib.gdb_wrapper.elf import read_elf_sects
+from lib.tools import AttrDict, memoized
+from lib.gdb_wrapper.x86 import Target, Operand, Instruction
+
+
+class MipsInstruction(Instruction):
+
+    def __init__(self, gdbstr):
+        Instruction.__init__(self, gdbstr)
+        self.gdbstr = gdbstr
+
+        # strip indicator
+        if self.gdbstr[0:2] == "=>":
+            self.gdbstr = self.gdbstr[2:]
+
+        # strip hints
+        c = 0
+        s = self.gdbstr
+        self.gdbstr = ""
+        for i in range(0, len(s)):
+            if s[i] == "<":
+                c += 1
+                continue
+            elif s[i] == ">":
+                c -= 1
+                continue
+            if c > 0:
+                continue
+            self.gdbstr += s[i]
+
+        toks = []
+        for t in self.gdbstr.split():
+            t = t.strip().strip(":")
+            if t:
+                toks.append(t)
+        self.addr = int(toks[0], 16)
+
+        self.mnemonic = toks[1]
+        self.inst = " ".join(toks[2:])
+
+        if self.inst == "":  # handle "ret", "iret", et al.
+            return
+
+        # get operands
+        self.operands = [MipsOperand(o) for o in self.inst.split(",")]
+        for a, o in zip(self.__get_operand_order(self.mnemonic), self.operands):
+            setattr(self, a, o)
+
+    def __get_operand_order(self, mnemonic):
+        # TODO: add more instructions
+        # http://www.mrc.uidaho.edu/mrc/people/jff/digital/MIPSir.html
+
+        # possbible orders
+        # TODO: "aux" needs to be in orders?
+        dst = ["dest", "source", "source2"]  # e.g. add
+        dsi = ["dest", "source", "immediate"]  # e.g. addi
+        std = ["source", "source2", "dest"]  # e.g. beq
+        sd = ["source", "dest"]  # e.g. bgez
+        ss = ["source", "source2"]  # e.g. div
+        d = ["dest"]  # e.g. j
+        ds = ["dest", "source"]  # e.g. lb
+        di = ["dest", "immediate"]  # e.g. lui
+
+        # mapping from instruction to operand order
+        operand_dict = {
+            "add": dst,
+            "addi": dsi,
+            "addiu": dsi,
+            "addu": dst,
+            "and": dst,
+            "andi": dsi,
+            "b": d,
+            "bal": d,
+            "beq": std,
+            "bgez": sd,
+            "bgezal": sd,
+            "bgtz": sd,
+            "blez": sd,
+            "bltz": sd,
+            "bltzal": sd,
+            "bne": std,
+            "div": ss,
+            "divu": ss,
+            "j": d,
+            "jal": d,
+            "jar": d,
+            "lb": ds,
+            "lbu": ds,
+            "lui": di,
+            "lw": ds,
+            "mfhi": d,
+            "mflo": d,
+            "mult": ss,
+            "multu": ss,
+            "or": dst,
+            "ori": dsi,
+            "sb": sd,
+            "sll": dsi,
+            "sllv": dst,
+            "slt": dst,
+            "slti": dsi,
+            "sltiu": dsi,
+            "sltu": dst,
+            "sra": dsi,
+            "srl": dsi,
+            "srlv": dst,
+            "sub": dst,
+            "subu": dst,
+            "sw": sd,
+            "xor": dst,
+            "xori": dsi
+        }
+
+        if mnemonic in operand_dict:
+            return operand_dict[mnemonic]
+        else:
+            print("[MipsOperand] Unknown mnemonic %s. Please update order dict!" % mnemonic)
+            return []
+
+
+class MipsOperand(Operand):
+    '''
+    A disassembled instruction operand that can be evaluated. Notable
+    attributes include:
+
+    gdbstr - the original string of disassembled operand that was used to
+        populate this instance
+    is_pointer - True if this operand represents a pointer, False otherwise.
+        For example, "DWORD PTR [eax]" is considered a pointer, "eax" is not.
+    regs - a list of strings representing the registers used in this Operand
+   '''
+
+    _re_hex = re.compile(r'^(-?0x[0-9a-fA-F]+)$')
+    _re_addr = re.compile(r""" (-?0?x?[A-Fa-f0-9]*)\(([a-z]{1,5}\d{0,2}[a-z]{0,1})\)$    # "0x10($sp) or -0x7fa0($gp)"
+                           """, re.VERBOSE)
+    _re_regstrs = re.compile(
+        r"""([a-z]{1,5}\d{0,2}[a-z]{0,1})                               # "$ra or $t9"
+                 """, re.VERBOSE)
+    _re_p_regs = re.compile(r"zero")
+
+    def __init__(self, gdbstr):
+        '''
+        Parses gdbstr to populate self.  ex gdbstr="BYTE PTR es:[edi]"
+        '''
+        self.gdbstr = gdbstr
+        gdbstr = gdbstr.split("<")[0]  # get rid of "<addr resolutions>"
+
+        # check if hexadecimal immediate value
+        imm = self._re_hex.match(gdbstr)
+        if imm:
+            self.is_pointer = False
+            expr = [m for m in imm.groups() if m][0]
+
+        # get addr
+        addr = self._re_addr.match(gdbstr)  # ignores segment regs
+        if addr:
+            self.is_pointer = True
+            expr = "+".join([m for m in addr.groups() if m])
+        else:
+            self.is_pointer = False
+            expr = gdbstr
+
+        # the MIPS register $zero/$0 evaluates always to 0
+        expr = self._re_p_regs.sub("0", expr)
+
+        self.regs = [t.group() for t in self._re_regstrs.finditer(expr)]
+        # prep for GDB evaluation. ex: "edx+0x12" becomes "$edx+0x12"
+        if not imm:
+            self.expr = self._re_regstrs.sub(
+                (lambda mo: "${}".format([mg for mg in mo.groups() if mg][0])), expr)
+        else:
+            self.expr = expr
+
+
+class MipsTarget(Target):
+    '''
+    A wrapper for an ARM Linux GDB Inferior.
+    '''
+
+    def _getInstruction(self, gdbstr):
+        return MipsInstruction(gdbstr)

--- a/exploitable/tests/Makefile.mips
+++ b/exploitable/tests/Makefile.mips
@@ -1,0 +1,44 @@
+## Makefile for building triage test binaries.
+## The explicitly declared file targets below may cause Makefile warnings
+## due to redefinition -- this is a known issue. They may safely be ignored.
+BIN_DIR=./bin
+TEST_FILE_EXT=.test
+
+CC=mips-linux-gnu-gcc-7 -g
+CPP=mips-linux-gnu-cpp-7 -g
+
+C_SRC=$(wildcard *.c)
+CPP_SRC=$(wildcard *.cpp)
+
+C_TESTS=$(C_SRC:.c=$(TEST_FILE_EXT))
+CPP_TESTS=$(CPP_SRC:.cpp=$(TEST_FILE_EXT))
+EXCLUDE=testBranchAv.test testBlockMoveAv.test testDestAv.test testDestAvNearNull.test testSourceAvNearNull.test testBranchAvNearNull.test
+TESTS=$(filter-out $(EXCLUDE), $(C_TESTS) $(CPP_TESTS))
+
+all: $(TESTS)
+
+$(TESTS): | $(BIN_DIR)
+
+$(BIN_DIR):
+	mkdir $(BIN_DIR)
+
+$(C_TESTS): %$(TEST_FILE_EXT): %.c
+	$(CC) -o $(BIN_DIR)/$@ $<
+
+$(CPP_TESTS): %$(TEST_FILE_EXT): %.cpp
+	$(CPP) -o $(BIN_DIR)/$@ $<
+
+testStackCodeExecution.test: %$(TEST_FILE_EXT): %.c
+	${CC} -o $(BIN_DIR)/$@ $<
+	execstack -s $(BIN_DIR)/$@
+
+testStackBufferOverflow.test: %$(TEST_FILE_EXT): %.c
+	${CC} -fstack-protector-all -o $(BIN_DIR)/$@ $<
+
+testReturnAv.test: %$(TEST_FILE_EXT): %.c
+	${CC} -fno-stack-protector -o $(BIN_DIR)/$@ $<
+
+.PHONY: clean
+clean:
+	-rm $(addprefix $(BIN_DIR)/,$(TESTS))
+	-rmdir $(BIN_DIR)


### PR DESCRIPTION
I implemented initial support for the MIPS CPU architecture. I needed this to triage many crashes on a MIPS router (big endian, 32 bits). There are no tests. However, for my use case it just worked fine. Therefore, I believe that this may be interesting/beneficial to the rest of the community. 

There is an additional makefile `exploitable/tests/Makefile.mips` that cross-compiles the examples for MIPS big endian 32 bits (the target of my use case). The coverage of instructions in `exploitable/lib/gdb_wrapper/mips.py` is not optimal but it is a start for future work. Another branch of future work would be to consider other C runtimes like uClibc (and hence adjust the analyzers in `exploitable/lib/analyzers/mips.py`).