### PR TITLE
Make exploitable compatible with GDB 10.X

### DIFF
--- a/exploitable/exploitable.py
+++ b/exploitable/exploitable.py
@@ -85,6 +85,7 @@ sys.path.append(os.path.dirname(abspath))
 import lib.classifier as classifier
 import lib.arch as arch
 from lib.tools import print_machine_string
+from distutils.version import LooseVersion
 
 def check_version():
     '''
@@ -95,7 +96,7 @@ def check_version():
     '''
 
     # check GDB ver
-    if gdb_ver() < "7.2":
+    if LooseVersion(gdb_ver()) < LooseVersion("7.2"):
         warnings.warn("GDB v{} may not support required Python API".format(gdb_ver()))
 
 _re_gdb_version = re.compile(r"\d+\.\d+")

--- a/exploitable/lib/arch.py
+++ b/exploitable/lib/arch.py
@@ -83,12 +83,16 @@ def getTarget(asan_log_file=None, bt_limit=0):
     # Get OS info.  TODO: verify this works on older versions of GDB (7.2)
     osabi = Target._re_gdb_osabi.search(str(gdb.execute("show osabi", False,
                                                         True))).group(1)
-    arch_str = str(gdb.execute("show architecture", False, True))
-    # if we set the arch in gdbmultiarch it is "assumed"
-    if "assumed" in arch_str:
-        arch = arch_str
-    else:
-        arch = Target._re_gdb_arch.search(arch_str).group(1)
+    # Try to use python API to determine architecture.
+    arch = gdb.selected_frame().architecture().name()
+    # Fallback parsing
+    if arch == None:
+        arch_str = str(gdb.execute("show architecture", False, True))
+        # if we set the arch in gdbmultiarch it is "assumed"
+        if "assumed" in arch_str:
+            arch = arch_str
+        else:
+            arch = Target._re_gdb_arch.search(arch_str).group(1)
 
     # Instantiate a target based on the params and OS info
     # ASAN + i386 + *

--- a/exploitable/lib/gdb_wrapper/x86.py
+++ b/exploitable/lib/gdb_wrapper/x86.py
@@ -480,7 +480,7 @@ class Target(object):
                                        of\s+(?P<lib>.*?)\s*)?$""", re.VERBOSE)
     _re_gdb_addr_bit = re.compile(r"^gdbarch_dump: addr_bit = ([0-9]+)$", re.MULTILINE)
     _re_gdb_osabi = re.compile(r"\(\w+ \"(.*)\"\)")
-    _re_gdb_arch = re.compile(r"\(\w+\s+(.+)\)")
+    _re_gdb_arch = re.compile(r"\(\w+\s+\"*(.+?)\"*\)")
 
     # these functions and libs are not considered to be at fault for a crash
     blacklist = AttrDict(functions=("__kernel_vsyscall", "abort", "raise",


### PR DESCRIPTION
In some distribution (at least Arch and Kali) GDB 10 has landed. It observed it to break two things.

1. The version check against "7.2" does not correcty work because "10" is smaller than "7" this minor issue is fixed in e942e28370e318e8f1dc030248b4e4517c1239f2
2. The output of `show architecture` has changed.

In GDB 9.2 (tested in Xubuntu 20.04)

```
show architecture
The target architecture is set automatically (currently i386).
```

In GNU gdb (GDB) 10.1 in Arch and Kali
```
show architecture
The target architecture is set to "auto" (currently "i386:x86-64").
```

0db4542ee139a38027e1eee8b98125dcfd72b75b adjusts the regex that is used parsing the architecture. However as a default the python API is now used to determine the architecture. If this falls the old functionality is used. 